### PR TITLE
Remvove user_stores from schema

### DIFF
--- a/db/migrate/20151205231200_drop_user_stores.rb
+++ b/db/migrate/20151205231200_drop_user_stores.rb
@@ -1,0 +1,5 @@
+class DropUserStores < ActiveRecord::Migration
+  def change
+    drop_table :user_stores
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151204035330) do
+ActiveRecord::Schema.define(version: 20151205231200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,16 +86,6 @@ ActiveRecord::Schema.define(version: 20151204035330) do
   add_index "user_roles", ["role_id"], name: "index_user_roles_on_role_id", using: :btree
   add_index "user_roles", ["user_id"], name: "index_user_roles_on_user_id", using: :btree
 
-  create_table "user_stores", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "store_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  add_index "user_stores", ["store_id"], name: "index_user_stores_on_store_id", using: :btree
-  add_index "user_stores", ["user_id"], name: "index_user_stores_on_user_id", using: :btree
-
   create_table "users", force: :cascade do |t|
     t.string   "username"
     t.string   "password_digest"
@@ -115,6 +105,4 @@ ActiveRecord::Schema.define(version: 20151204035330) do
   add_foreign_key "items", "stores"
   add_foreign_key "user_roles", "roles"
   add_foreign_key "user_roles", "users"
-  add_foreign_key "user_stores", "stores"
-  add_foreign_key "user_stores", "users"
 end


### PR DESCRIPTION
Removed user_stores table due to the client request to have a 1 to many relationship between user and store instead of many-to-many.
