### PR TITLE
Closes #13-platform admin can take a business offline

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,9 +3,4 @@ class DashboardController < ApplicationController
     @store = current_user.store
     @orders = @store.orders
   end
-
-  # def show
-  #   @store = current_user.store
-  #   @orders = Order.desc_by_date
-  # end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,7 +30,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    # require 'pry';binding.pry
     @item = Item.find_by(slug: params[:slug])
   end
 

--- a/app/controllers/platform/dashboard_controller.rb
+++ b/app/controllers/platform/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class Platform::DashboardController < Platform::BaseController
   def index
-    @active_stores = Store.where(status: "accepted")
-    @pending_stores = Store.where(status: "Pending")
-    @declined_stores = Store.where(status: "declined")
+    @active_stores ||= Store.where(status: "accepted")
+    @pending_stores ||= Store.where(status: "Pending")
+    @declined_stores ||= Store.where(status: "declined") # will this ||= allow us not to have to re query the database when reloading this page?
   end
 end

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -1,6 +1,6 @@
 class StoresController < ApplicationController
   def index
-    @stores = Store.all
+    @stores = Store.where(status: "accepted")
   end
 
   def show

--- a/app/views/platform/dashboard/index.html.erb
+++ b/app/views/platform/dashboard/index.html.erb
@@ -2,7 +2,7 @@
 <div class="row">
   <div class="col s6 m6 l6">
     <div id='active-stores'>
-      <table id="" class='table-striped table-bordered table-hover'>
+      <table class='table-striped table-bordered table-hover'>
         <h4>Current Farms</h4>
         <tr>
           <th>Farm</th>
@@ -11,7 +11,7 @@
         <% @active_stores.each do |store| %>
         <tr>
           <td><%= link_to "#{store.name}", "/#{store.slug}" %></td>
-          <td> "Take Offline" </td>
+          <td id=<%="remove-#{store.id}"%>><%= button_to "Take Offline", platform_store_path(store, edit_action: "Pending"), method: :patch  %></td>
         </tr>
         <% end %>
       </table>
@@ -45,6 +45,7 @@
         <% @declined_stores.each do |store| %>
         <tr>
           <td><%= link_to "#{store.name}", "/#{store.slug}" %></td>
+          <td id=<%="pend-#{store.id}"%>><%= button_to "Make Pending", platform_store_path(store, edit_action: "Pending"), method: :patch %></td>
         </tr>
         <% end %>
       </table>

--- a/app/views/shared/_admin_nav.html.erb
+++ b/app/views/shared/_admin_nav.html.erb
@@ -1,1 +1,28 @@
-
+<nav class="black">
+  <div class="nav-wrapper">
+    <a href="/" class="brand-logo">Pivot Produce</a>
+    <a href="#" data-activates="mobile-demo" class="button-collapse"><i class="material-icons">menu</i></a>
+    <ul class="right hide-on-med-and-down" style = "padding-right: 10px">
+      <li> <%= link_to "All Items", items_path %> </li>
+      <li> <%= link_to "Categories", categories_path %> </li>
+      <li> <%= link_to "Our Farmers", farmers_path %>
+      <% if current_user %>
+        <li><%= link_to "Profile", dashboard_path %></li>
+        <li><%= link_to "Logout", logout_path, method: :delete %></li>
+      <% else %>
+        <li><%= link_to "Login", login_path %></li>
+        <li><%= link_to "Create Account", new_user_path %></li>
+      <% end %>
+      <li><%= link_to "Cart (#{@cart.cart_size})", cart_items_path %> </li>
+      <li><i class="material-icons">shopping_cart</i></li>
+    </ul>
+  </div>
+</nav>
+<% if store_admin? %>
+  <nav class="#eceff1 blue-grey lighten-5">
+    <li class="brand-logo black-text" style="stationary-text">Administrator</li>
+    <ul class="right hide-on-med-and-down">
+      <li><%=link_to "Dashboard", store_dashboard_index_path(store: current_user.store.slug), class: "black-text" %></li>
+      <li><%=link_to "View Store", "/""#{current_store.slug}", class: "black-text" %></li></ul>
+  </nav>
+<% end %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -3,6 +3,9 @@
     <a href="/" class="brand-logo">Pivot Produce</a>
     <a href="#" data-activates="mobile-demo" class="button-collapse"><i class="material-icons">menu</i></a>
     <ul class="right hide-on-med-and-down" style = "padding-right: 10px">
+      <% if current_user && current_user.platform_admin? %>
+        <li><%= link_to "Platform Dashboard", platform_dashboard_index_path %></li>
+      <% end %>
       <li> <%= link_to "All Items", items_path %> </li>
       <li> <%= link_to "Categories", categories_path %> </li>
       <li> <%= link_to "Our Farmers", farmers_path %>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -1,8 +1,3 @@
-<!-- <div class="search">
-  <i class="material-icons">search</i><%= text_field :name, :search_name, placeholder: "Enter name here" %>
-</div> -->
-
-<!-- <nav id="nav-search"> -->
 <div class="row">
        <span class="col s1 offset-s1">
          <label for="search"><i class="medium material-icons">search</i></label>
@@ -13,6 +8,3 @@
           </form>
         </span>
  </div>
-
-
- <!-- </nav> -->

--- a/test/integration/platform_admin_permission_service_test.rb
+++ b/test/integration/platform_admin_permission_service_test.rb
@@ -26,7 +26,6 @@ class PlatformAdminPermissionServiceTest < ActionDispatch::IntegrationTest
 
   test "a platform admin can visit items show" do
     item = Item.create!(name: "Thing", price: 3)
-    # require 'pry'; binding.pry
     visit item_path(item)
 
     assert item_path(item), current_path

--- a/test/integration/platform_admin_takes_business_offline_online_test.rb
+++ b/test/integration/platform_admin_takes_business_offline_online_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class PlatformAdminTakesStoreOfflineOnlineTest < ActionDispatch::IntegrationTest
+  def setup
+    create_platform_admin
+    create_active_store
+    @active_store2 = Store.create(name:"Second Store",
+                                   status: "accepted")
+    @active_store3 = Store.create(name:"Third Store",
+                                   status: "accepted")
+    login_platform_admin
+  end
+
+  test "platform admin can take a store offline" do
+    within("#active-stores") do
+      assert page.has_content?("Current Farms")
+      assert page.has_content?("#{@active_store.name}")
+      assert page.has_content?("#{@active_store2.name}")
+      assert page.has_content?("#{@active_store3.name}")
+    end
+
+    within("#remove-#{@active_store.id}") do
+      click_button "Take Offline"
+    end
+
+    within("#active-stores") do
+      refute page.has_content?("#{@active_store.name}")
+    end
+
+    within("#pending-stores") do
+      assert page.has_content?("#{@active_store.name}")
+    end
+
+    within("#decline-#{@active_store.id}") do
+      click_button "Decline Store"
+    end
+
+    within("#pending-stores") do
+      refute page.has_content?("#{@active_store.name}")
+    end
+
+    within("#declined-stores") do
+      assert page.has_content?("#{@active_store.name}")
+    end
+
+    within("#pend-#{@active_store.id}") do
+      click_button "Make Pending"
+    end
+
+    within("#accept-#{@active_store.id}") do
+      click_button "Put Online"
+    end
+
+    within("#active-stores") do
+      assert page.has_content?("#{@active_store.name}")
+    end
+  end
+end

--- a/test/integration/platform_admin_takes_business_offline_online_test.rb
+++ b/test/integration/platform_admin_takes_business_offline_online_test.rb
@@ -57,6 +57,14 @@ class PlatformAdminTakesStoreOfflineOnlineTest < ActionDispatch::IntegrationTest
   end
 
   test "a store taken offline can not be seen on the website to shop by" do
-    
+    visit stores_path
+    assert page.has_content?(@active_store.name)
+    click_link "Platform Dashboard"
+
+    within("#remove-#{@active_store.id}") do
+      click_button "Take Offline"
+    end
+    visit stores_path
+    refute page.has_content?(@active_store.name)
   end
 end

--- a/test/integration/platform_admin_takes_business_offline_online_test.rb
+++ b/test/integration/platform_admin_takes_business_offline_online_test.rb
@@ -55,4 +55,8 @@ class PlatformAdminTakesStoreOfflineOnlineTest < ActionDispatch::IntegrationTest
       assert page.has_content?("#{@active_store.name}")
     end
   end
+
+  test "a store taken offline can not be seen on the website to shop by" do
+    
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -72,7 +72,6 @@ class ActionDispatch::IntegrationTest
   def create_active_store
     @active_store = Store.create(name:"Some Active Store",
                         status: "accepted")
-                      
   end
 
   def create_pending_store


### PR DESCRIPTION
Platform admin can take a business offline in the Platform admin dashboard page
Now the stores shown on the site need to reflect this.
